### PR TITLE
Fixed artist and fan dashboard bug: clicking on events and deleting e…

### DIFF
--- a/src/components/ArtistDashBoard.jsx
+++ b/src/components/ArtistDashBoard.jsx
@@ -90,10 +90,12 @@ const EventText = styled.h4`
     font-weight: bold;
     color: #2D2D2D;
     margin: 5px;
+    pointer-events: none;
 `;
 
 const AddressText = styled.p`
     color: #8F8F8F;
+    pointer-events: none;
 `;
 
 export default function ArtistDashBoard({userId, setPage, setPageId}) {
@@ -125,7 +127,8 @@ export default function ArtistDashBoard({userId, setPage, setPageId}) {
   };
 
   const deleteEvent = (e) => {
-    console.log(e.target);
+    e.stopPropagation();
+    console.log(e);
     console.log('eventId', e.target.id);
     if (e.target.id) {
       apiMasters.artistDeleteEvent(userId, e.target.id)
@@ -151,17 +154,17 @@ export default function ArtistDashBoard({userId, setPage, setPageId}) {
       <EventList>
         <h4>Upcoming Events</h4>
         {events && events.map((event) => (
-          <EventDiv>
+          <EventDiv id={event.id} onClick={clickHandler}>
             <DateDiv>
               <DateText>{`${event.date}`}</DateText>
               <p style={{ color: '#259998' }}>{`${event.start_time}`}</p>
             </DateDiv>
-            <AddressDiv id={event.id} onClick={clickHandler}>
+            <AddressDiv>
               <EventText>{event.name}</EventText>
               <AddressText>{`${event.city}, ${event.state}`}</AddressText>
             </AddressDiv>
-            <TrashBoxDiv>
-              <FaTrashAlt onClick={deleteEvent} id={event.id} style={{ color: '#259998' }} />
+            <TrashBoxDiv onClick={deleteEvent} id={event.id}>
+              <FaTrashAlt style={{ color: '#259998', pointerEvents: 'none' }} />
             </TrashBoxDiv>
           </EventDiv>
         ))}

--- a/src/components/FanDashBoard.jsx
+++ b/src/components/FanDashBoard.jsx
@@ -28,6 +28,7 @@ const Card = styled.div`
 
 const StyleSpan = styled.span`
   font-size: 0.75em;
+  pointer-events: none;
 `;
 
 export default function FanDashBoard({ setPage, setPageId, userId }) {
@@ -84,7 +85,7 @@ export default function FanDashBoard({ setPage, setPageId, userId }) {
                     <EventsMImg alt='event pic' src={event.event_pic ? event.event_pic : 'https://cdn.choosechicago.com/uploads/2019/05/Belmont_Sheffield_Music_Fest_c698582a-9aec-4738-807f-5f7061c698f1-1024x612.png'} />
                   </div>
                   <div className='flip-card-back' onClick={showEvent} id={event.event_id}>
-                    <p>Event Name:<br/>{event.event_name}</p>
+                    <p style={{ pointerEvents: 'none' }}>Event Name:<br/>{event.event_name}</p>
                     <StyleSpan>Time:<br/>{`${event.date} ${event.start_time}`}</StyleSpan>
                   </div>
                 </div>


### PR DESCRIPTION
Clicking on events from the artist and fan dashboard correctly renders the event page no matter where the div is clicked. The delete event button now functions as expected and does not trigger any other clicks handlers.