### PR TITLE
Fixed bug that caused register modal to close on any click

### DIFF
--- a/src/components/Auth/RegisterModal.jsx
+++ b/src/components/Auth/RegisterModal.jsx
@@ -27,14 +27,14 @@ export default function RegisterModal({
   setLogin,
 }) {
   const [open, setOpen] = React.useState(!!anonymous);
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
   const [showForm, setShowForm] = React.useState('Register');
-  function handleClick() {
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => {
+    setOpen(false);
     if (anonymous) {
       setLogin(false);
     }
-  }
+  };
 
   return (
     <div>
@@ -44,8 +44,6 @@ export default function RegisterModal({
       <Modal
         open={open}
         onClose={handleClose}
-        // eslint-disable-next-line react/jsx-no-bind
-        onClick={handleClick}
         aria-labelledby='modal-modal-title'
         aria-describedby='modal-modal-description'
       >


### PR DESCRIPTION
- RegisterModal was closing on any click inside the form element IF the modal opened because an anonymous user tried to save an event or follow an artist. Found the source and fixed it.